### PR TITLE
Navigation for 'Visualize phenotype variation tree'

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -82,6 +82,11 @@
  			bc_text = 'Visualize phenotypic profile tree'
  			bc_url = '/phenotypes/profile_tree'
  			page_title = bc_text
+ 		when 'phenotypes, variation_tree'
+ 			bc_class = 'breadcrumb-visualize'
+ 			bc_text = 'Visualize phenotype variation tree'
+ 			bc_url = '/phenotypes/variation_tree/TAO:0000316'
+ 			page_title = bc_text
  		# TODO: Add 'Visualize Phenotype Variation Tree' when it's ready
 
  		# Other pages

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -94,7 +94,7 @@
                <ul>
                    <li><a href="/phenotypes/profile_tree">Phenotypic profile tree</a>
                         <a href="/hints/WebHints#VisualizePhenotypicProfileTree" class="help-link"><img src="/images/help.png" alt="help"></a></li>
-                   <li><a href="#">Phenotype variation tree</a>
+                   <li><%= link_to 'Phenotype variation tree', :controller => :phenotypes, :action => :variation_tree, :id => 'TAO:0000316' %>
                         <a href="/hints/WebHints#VisualizePhenotypicVariationTree" class="help-link"><img src="/images/help.png" alt="help"></a></li>
                </ul>
             </td>


### PR DESCRIPTION
Enabled home page link (and navigation breadcrumb) for 'Visualize phenotype variation tree', with initial phenotypa 'basihyal bone' (TAO:0000316)

N.B. This does not make the initial selection of 'shape' in the tree view, so the result is not very satisfying yet.
