### PR TITLE
Fixed session code to deal with CSRF protection changes in Rails 2.3.11.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
 
   # See ActionController::RequestForgeryProtection for details
   # Uncomment the :secret if you're not using the cookie session store
-  protect_from_forgery # :secret => '4933eb45f528a9555fe7cf6351fabc91'
+  protect_from_forgery :secret => '4933eb45f528a9555fe7cf6351fabc91'
   
   # See ActionController::Base for details 
   # Uncomment this to filter the contents of submitted sensitive data parameters

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -171,6 +171,7 @@
   <!-- jQuery libraries -->
   <%= javascript_include_tag "jquery-1.5.2.min.js" %>
   <%= javascript_include_tag "JSON.js" %>
+  <%= csrf_meta_tag %>
   <% javascript_tag do %>
   <!--
     $.noConflict();

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -5,7 +5,7 @@
 # ENV['RAILS_ENV'] ||= 'production'
 
 # Specifies gem version of Rails to use when vendor/rails is not present
-RAILS_GEM_VERSION = '2.3.5' unless defined? RAILS_GEM_VERSION
+RAILS_GEM_VERSION = '2.3.14' unless defined? RAILS_GEM_VERSION
 
 # Bootstrap the Rails environment, frameworks, and default configuration
 require File.join(File.dirname(__FILE__), 'boot')

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -2,6 +2,19 @@
 // This file is automatically included by javascript_include_tag :defaults
 
 
+/*
+ * Registers a callback which copies the csrf token into the
+ * X-CSRF-Token header with each ajax request.  Necessary to 
+ * work with rails applications which have fixed
+ * CVE-2011-0447
+*/
+
+jQuery(document).ajaxSend(function(e, xhr, options) {
+  var token = jQuery('meta[name="csrf-token"]').attr("content");
+  xhr.setRequestHeader("X-CSRF-Token", token);
+});
+
+
 // initializes an autocomplete text field using jquery
 function initAutocomplete(input_id, ontologyPrefixes, query_type, min_chars, width){
   if(!query_type){query_type='';}


### PR DESCRIPTION
@hlapp this is a fix to restore proper session functionality for the Workspace in the face of security updates within Rails.
